### PR TITLE
mavenでのbuildでworningになるため、pom.xmlを訂正

### DIFF
--- a/sample/jsug-shop/pom.xml
+++ b/sample/jsug-shop/pom.xml
@@ -68,11 +68,6 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-configuration-processor</artifactId>
-      <optional>true</optional>
-    </dependency>
 
     <!-- war生成時に組み込みTomcatを除外する設定。 -->
     <!-- warのファイルサイズを削減するために、必須と言って良い。 -->


### PR DESCRIPTION
spring-boot-configuration-processorが複数指定されていたため、片方を削除。
fix #2